### PR TITLE
chore: setting up swagger API documentation tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
   "author": " Scrum master",
   "license": "ISC",
   "dependencies": {
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jsend": "^1.1.0",
     "nodemon": "^3.1.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "typescript-jsend": "^0.1.1"

--- a/src/configs/swagger.ts
+++ b/src/configs/swagger.ts
@@ -1,0 +1,30 @@
+import swaggerJSDoc from "swagger-jsdoc";
+import { getSwaggerServer } from "../startups/getSwaggerServer";
+
+const swaggerServer = getSwaggerServer();
+
+const options: swaggerJSDoc.Options = {
+  definition: {
+    openapi: "3.0.1",
+    info: {
+      title: "Knights E-commerce API Documentation",
+      version: "1.0.0",
+      description: "knights E-commerce - Backend API",
+    },
+    servers: [{ url: swaggerServer }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "JWT",
+        },
+      },
+    },
+  },
+  apis: ["./src/docs/*.ts", "./src/docs/*.yml"],
+};
+
+const swaggerSpec = swaggerJSDoc(options);
+
+export default swaggerSpec;

--- a/src/docs/index.yml
+++ b/src/docs/index.yml
@@ -1,0 +1,23 @@
+/:
+  get:
+    tags:
+      - index
+    summary: "initial endpoint"
+    description: "This is initial endpoint"
+    responses:
+      "200":
+        description: "success response"
+      "500":
+        description: "server error"
+
+/status:
+  get:
+    tags:
+      - testing
+    summary: "status endpoint"
+    description: "This is status endpoint"
+    responses:
+      "200":
+        description: "success response"
+      "500":
+        description: "server error"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,23 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import router from "./routes";
+import { addDocumentation } from "./startups/docs";
+
 dotenv.config();
 
 const app = express();
-const port = process.env.PORT as string
+const port = process.env.PORT as string;
 app.use(express.json());
 
-app.use(cors());
+app.use(cors({ origin: "*" }));
 
-app.get('/', (req: Request, res: Response) => {
-    res.send('Knights Ecommerce API');
+addDocumentation(app);
+app.get("/api/v1", (req: Request, res: Response) => {
+  res.send("Knights Ecommerce API");
 });
-app.use(router)
+
+app.use(router);
+
 app.listen(port, () => {
-    console.log(`[server]: Server is running at http://localhost:${port}`);
-})
+  console.log(`[server]: Server is running at http://localhost:${port}/api/v1`);
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,9 +1,9 @@
 import { Request, Response, Router } from "express";
 import { responseSuccess } from "../utils/response.utils";
 const router = Router();
-router.get("/status", (req: Request, res: Response) => {
-    return responseSuccess(res, 202, "This is a testing route that returns: 201");
-})
+router.get("/api/v1/status", (req: Request, res: Response) => {
+  return responseSuccess(res, 202, "This is a testing route that returns: 201");
+});
 // All routes should be imported here and get export after specifying first route
 // example router.use("/stock". stockRoutes) =>:: First import stockRoutes and use it here, This shows how the route export will be handled
 

--- a/src/startups/docs.ts
+++ b/src/startups/docs.ts
@@ -1,0 +1,7 @@
+import { type Express } from "express";
+import swaggerUI from "swagger-ui-express";
+import swagger from "../configs/swagger";
+
+export const addDocumentation = (app: Express): void => {
+  app.use("/api/v1/docs", swaggerUI.serve, swaggerUI.setup(swagger));
+};

--- a/src/startups/getSwaggerServer.ts
+++ b/src/startups/getSwaggerServer.ts
@@ -1,0 +1,13 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+function getSwaggerServer(): string {
+  if (process.env.SWAGGER_SERVER !== undefined) {
+    return process.env.SWAGGER_SERVER;
+  }
+
+  return "http://localhost:7000/api/v1";
+}
+
+export { getSwaggerServer };


### PR DESCRIPTION
#### What does this PR do?

This pull request aims to add swagger API documentation to knights-ecomm-be project

#### Description of Task to be completed?

The task completed in this pull request includes:

- setting up swagger API documentation tool in project
- adding endpoint to access swagger documentation ui

#### How should this be manually tested?

To manually test all the changes made in this pull request, follow these steps:

```
git clone -b ft-api-docs https://github.com/atlp-rwanda/knights-ecomm-be.git
cd knights-ecomm-be
npm i
npm run dev
access http://localhost:{port}/api/v1/docs
```